### PR TITLE
Added -source version to pom to not run into compile issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,16 @@
                     <mainClass>com.amazonaws.samples.S3Sample</mainClass>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
mvn clean compile did not work, because the source/target version for java was not set. Therefore maven uses Java version 1.3 as default. I added version configuration to avoid this. You may want to change it to 1.6 or whatever :)
