### PR TITLE
Fixing compiler error "Source option 5 is no longer supported"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,9 @@
     <url>http://aws.amazon.com/sdkforjava</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	    <maven.compiler.source>1.6</maven.compiler.source>
+	    <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
When trying to build the project with Maven, this error would be thrown:

"Source option 5 is no longer supported. Use 6 or later."

This fixes it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
